### PR TITLE
Fix stored_access_token reference.

### DIFF
--- a/Lesson4/step2/project.py
+++ b/Lesson4/step2/project.py
@@ -171,7 +171,7 @@ def gconnect():
 
     stored_access_token = login_session.get('access_token')
     stored_gplus_id = login_session.get('gplus_id')
-    if stored_credentials is not None and gplus_id == stored_gplus_id:
+    if stored_access_token is not None and gplus_id == stored_gplus_id:
         response = make_response(json.dumps('Current user is already connected.'),
                                  200)
         response.headers['Content-Type'] = 'application/json'


### PR DESCRIPTION
Previous change https://github.com/udacity/ud330/commit/9b7be92927ecc6faf6ef7ce24cf2c865fa823765#diff-bdd4405b63dd404e3b116ab1a317a74d changed stored_credentials to stored_access_token but missed one reference.